### PR TITLE
feat: add Frisco, TX to US locations mapping

### DIFF
--- a/src/static/us_locations.ts
+++ b/src/static/us_locations.ts
@@ -120,6 +120,8 @@ export const US_CITIES: Record<string, string> = {
   塔尔萨: 'Tulsa',
   阿灵顿: 'Arlington',
   新奥尔良: 'New Orleans',
+  // Texas cities without common Chinese names
+  弗里斯科: 'Frisco',
 };
 
 // City to state mapping (English names)
@@ -181,4 +183,5 @@ export const CITY_TO_STATE: Record<string, string> = {
   Tulsa: 'Oklahoma',
   Arlington: 'Texas',
   'New Orleans': 'Louisiana',
+  Frisco: 'Texas',
 };


### PR DESCRIPTION
## Summary
- Add Frisco to US_CITIES mapping so runs in Frisco, TX are properly recognized
- Add Frisco to CITY_TO_STATE mapping for state inference

This fixes the issue where Frisco runs were not showing up in location statistics because the city wasn't recognized.

## Test plan
- [x] Verify Frisco appears in city statistics dropdown
- [x] Verify Frisco runs are visible on the map